### PR TITLE
Small bugfix in namespace name generation from remote machine name

### DIFF
--- a/launch_remote_ssh/launch_remote_ssh/execute_process_remote_ssh.py
+++ b/launch_remote_ssh/launch_remote_ssh/execute_process_remote_ssh.py
@@ -149,7 +149,7 @@ class ExecuteProcessRemoteSSH(LaunchDescription):
                     package='launch_remote_ssh',
                     executable='remote_process_handler',
                     name='remote_process_handler_' + self.uuid_short,
-                    namespace=ReplaceTextSubstitution(self.__machine, '.', '_'),
+                    namespace=['machine_',ReplaceTextSubstitution(ReplaceTextSubstitution(self.__machine, '.', '_'),'-','_')],
                     output='screen',
                     parameters=[{'screen_process_name': process_name_list}],
                     condition=self.__condition,


### PR DESCRIPTION
This minor tweak enables specifying machine names by IP address by adding "machine_" at the beginning of the namespace (since ROS namespaces cannot start with a number). Furthermore, it supports hostnames containing hyphens, which are also replaced by underscores.